### PR TITLE
Add --no-post option

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ I'll let the script speak for itself:
 $ slack -h
 
 usage: slack [-h] [-w WEBHOOK_URL] [-c CHANNEL] [-u USERNAME] [-i ICON_URL]
-             [-e ICON_EMOJI] [-a] [-C COLOR] [-t TITLE] [-n]
+             [-e ICON_EMOJI] [-a] [-C COLOR] [-t TITLE] [-d]
              text
 
 positional arguments:
@@ -75,7 +75,7 @@ optional arguments:
                         set the attachment color
   -t TITLE, --title TITLE
                         set the attachment title
-  -n, --no-post         do not post request but just print json body and exit
+  -d, --dump-json       do not post request but just print json body and exit
 ```
 
 ### Examples

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ I'll let the script speak for itself:
 $ slack -h
 
 usage: slack [-h] [-w WEBHOOK_URL] [-c CHANNEL] [-u USERNAME] [-i ICON_URL]
-             [-e ICON_EMOJI] [-a] [-C COLOR] [-t TITLE]
+             [-e ICON_EMOJI] [-a] [-C COLOR] [-t TITLE] [-n]
              text
 
 positional arguments:
@@ -75,6 +75,7 @@ optional arguments:
                         set the attachment color
   -t TITLE, --title TITLE
                         set the attachment title
+  -n, --no-post         do not post request but just print json body and exit
 ```
 
 ### Examples

--- a/slack/cli.py
+++ b/slack/cli.py
@@ -19,11 +19,11 @@ def main():
     parser.add_argument('-a', '--attachment', help='send message as a rich attachment', action='store_true', default=False)
     parser.add_argument('-C', '--color', help='set the attachment color')
     parser.add_argument('-t', '--title', help='set the attachment title')
-    parser.add_argument('-n', '--no-post', help='do not post request but just print json body and exit', action='store_true', default=False)
+    parser.add_argument('-d', '--dump-json', help='do not post request but just print json body and exit', action='store_true', default=False)
 
     args = parser.parse_args()
 
-    if args.webhook_url is None and not args.no_post:
+    if args.webhook_url is None and not args.dump_json:
         sys.stderr.write('No webhook URL given.\nEither use the -w/--webhook-url argument or the SLACK_WEBHOOK_URL environment variable.\n')
         return 1
 
@@ -68,7 +68,7 @@ def main():
     elif args.icon_emoji is not None:
         payload['icon_emoji'] = args.icon_emoji
 
-    if args.no_post:
+    if args.dump_json:
         sys.stdout.write('{0}\n'.format(json.dumps(payload)))
         return 0
 

--- a/slack/cli.py
+++ b/slack/cli.py
@@ -19,10 +19,11 @@ def main():
     parser.add_argument('-a', '--attachment', help='send message as a rich attachment', action='store_true', default=False)
     parser.add_argument('-C', '--color', help='set the attachment color')
     parser.add_argument('-t', '--title', help='set the attachment title')
+    parser.add_argument('-n', '--no-post', help='do not post request but just print json body and exit', action='store_true', default=False)
 
     args = parser.parse_args()
 
-    if args.webhook_url is None:
+    if args.webhook_url is None and not args.no_post:
         sys.stderr.write('No webhook URL given.\nEither use the -w/--webhook-url argument or the SLACK_WEBHOOK_URL environment variable.\n')
         return 1
 
@@ -66,6 +67,10 @@ def main():
         payload['icon_url'] = args.icon_url
     elif args.icon_emoji is not None:
         payload['icon_emoji'] = args.icon_emoji
+
+    if args.no_post:
+        sys.stdout.write('{0}\n'.format(json.dumps(payload)))
+        return 0
 
     try:
         res = requests.post(args.webhook_url, data=json.dumps(payload))


### PR DESCRIPTION
Add an option that do not post request but just output json body to stdout.

Purposes:

- Debugging without actual request
- Using output to pass through another commands